### PR TITLE
Only test on macOS for now.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
Bazel homebrew formula doesn't provide bottles for linuxbrew.
Disable the test flow on ubuntu for now.

See [test log](https://github.com/google/homebrew-verible/pull/2/checks?check_run_id=2410667511)
