### PR TITLE
Add git revision to verible formula.

### DIFF
--- a/Formula/verible.rb
+++ b/Formula/verible.rb
@@ -2,7 +2,8 @@ class Verible < Formula
   desc "SystemVerilog developer tools"
   homepage "https://github.com/google/verible"
   url "https://github.com/google/verible.git",
-      tag: "v0.0-1129-gfc4574e"
+      tag:      "v0.0-1129-gfc4574e",
+      revision: "fc4574ee582438800d7b9328cbe4dd99cfc84171"
   version "0.0-1129-gfc4574e"
   license "Apache-2.0"
 


### PR DESCRIPTION
`brew bump-formula-pr` expects a git commit hash in addition to the git tag.

`brew bump-formula-pr` will be used to automatically update the verible version (including the git tag and commit hash). Not updating the (outdated) tag for now, to allow experimentation with version bumps.
