### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           branch: main
 
       - name: Delete branch
-        if: github.event.pull_request.head.repo.fork == false
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: git push --delete origin $BRANCH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,5 +78,5 @@ jobs:
         uses: actions-ecosystem/action-add-labels@v1
         if: ${{ steps.regex-match.outputs.match != '' }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
           labels: pr-pull

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,13 +4,22 @@ on:
     branches:
       - main
   pull_request:
+
 jobs:
+
   test-bot:
     strategy:
       matrix:
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,3 +51,32 @@ jobs:
         with:
           name: bottles
           path: '*.bottle.*'
+
+  # Add `pr-pull` label after `test-bot` job completes, if:
+  # - triggered by pull_request
+  # - pull_request is not a draft
+  # - pull_request is not from a fork (implies write permission)
+  # - pull_request contains `AUTO_MERGE` line in the PR body
+  label-auto-merge:
+    needs: test-bot
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check pull request for AUTO_MERGE line
+        id: regex-match
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.event.pull_request.body }}
+          regex: '^AUTO_MERGE$'
+          flags: 'm'
+
+      - name: Label pull request with pr-pull label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: pr-pull


### PR DESCRIPTION
This pull requests implements a workflow for automated releases from formula version bump pull requests.

When a direct pull request (not from a fork) is made, with AUTO_MERGE in the pull request message, then a `pr-pull` label will be applied to the pull request, which will trigger the `brew pr-pull` workflow from `publish.yml`. The direct pull request requires write access to the repo.

A access token secret called `WORKFLOW_TOKEN` is required to be able to trigger the `brew pr-pull` workflow from the `brew test-bot` workflow.

The command to trigger the automated version bump release:
```
brew bump-formula-pr --no-fork --message AUTO_MERGE --tag <verible_tag> --version <verible_version> google/verible/verible
```
where `verible_tag` is the verible tag to bump the formula to (`v0.0-1234-g89abcde`) and `verible_version` is the corresponding version with the leading `v` (`0.0-1234-g89abcde`).

Tested on forked repo.
